### PR TITLE
python  버전 3.11 고정 테스트 진행

### DIFF
--- a/.github/workflows/pytest-django.yml
+++ b/.github/workflows/pytest-django.yml
@@ -1,0 +1,30 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.12, 3.11, 3.10]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run Tests
+      run: |
+        pytest

--- a/.github/workflows/pytest-django.yml
+++ b/.github/workflows/pytest-django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.12, 3.11, 3.10]
+        python-version: [3.12, 3.11]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,6 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run Tests
+    - name: Run Pytest Code Tests
       run: |
         pytest

--- a/.github/workflows/pytest-django.yml
+++ b/.github/workflows/pytest-django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.12, 3.11]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
python  버전 3.11 고정 테스트 진행
* 추후 버전 관련 체크

drf_yasg 라이브러리 3.11까지 지원
[github 링크](https://github.com/axnsan12/drf-yasg/tree/db42d356fb419a8fc334f2e369c1b721f27fc0b9?tab=readme-ov-file#drf-yasg---yet-another-swagger-generator)